### PR TITLE
Add tokenizer model selection and token count

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ This enhancement ensures CodeLLM Bridge starts reliably even when network folder
 - **Comment Stripping**: Optionally remove comments from copied code blocks
   - Programming language is detected automatically per file
   - Reduces the number of tokens sent to the AI for analysis
+- **Token Counting**: Select an OpenAI model and display token count after copying
+  - Uses `tiktoken` for accurate counts
+  - Default model is `o3`
 - **Temporary File Export**: Save content to a temporary file and copy the file to clipboard
   - Ideal for large codebases that exceed AI input field character limits
   - Creates timestamped temporary files that can be uploaded to AI tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # requests==2.25.1
 # numpy>=1.20 
 global-hotkeys
-keyboard
-pyperclip 
+keyboardpyperclip
+tiktoken>=0.9


### PR DESCRIPTION
## Summary
- integrate `tiktoken` docstring and add requirement
- add default model setting and UI combobox for model selection
- store selected model in profile settings
- show token counts when copying to clipboard or to temp files
- document token counting feature

## Testing
- `python -m py_compile CodeLLM_Bridge.py`

------
https://chatgpt.com/codex/tasks/task_e_686d47f196e48324bee999ee793a304f